### PR TITLE
Fix crash on savePlayAndRename when no valid play was active

### DIFF
--- a/src/dialogs/mainDialog.cpp
+++ b/src/dialogs/mainDialog.cpp
@@ -157,7 +157,6 @@ void MainDialog::enableMenuOptions() {
             action->setEnabled(true);
         }
     }
-    ui->generalInfoBox->setEnabled(true);
 }
 
 
@@ -220,6 +219,8 @@ void MainDialog::fillPlayInfoDock(PBCPlaySP play) {
     ui->playNameLineEdit->setText(QString::fromStdString(play->name()));
     ui->codeNameLineEdit->setText(QString::fromStdString(play->codeName()));
     ui->commentTextEdit->setText(QString::fromStdString(play->comment()));
+    ui->generalInfoBox->setEnabled(true);
+    ui->groupBox_6->setEnabled(true);
 }
 
 void MainDialog::fillPlayerInfoDock(PBCPlayerSP player) {

--- a/src/dialogs/mainDialog.ui
+++ b/src/dialogs/mainDialog.ui
@@ -111,6 +111,9 @@
      </property>
      <item>
       <widget class="QGroupBox" name="groupBox_6">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="title">
         <string>General Info</string>
        </property>

--- a/src/gui/pbcPlayView.cpp
+++ b/src/gui/pbcPlayView.cpp
@@ -187,6 +187,9 @@ void PBCPlayView::renameAndSavePlay(const std::string& name,
     // FIXME(obr): dirty hack to check if the play can be rendered (no PBCRenderingException occurs)
     repaint();
 
+    if (!_currentPlay)
+        return;
+
     PBCController::getInstance()->getPlaybook()->deletePlay(_currentPlay->name());
     _currentPlay->setName(name);
     _currentPlay->setCodeName(codeName);


### PR DESCRIPTION
For UI, the component is disabled on start.
For core, actually check if the pointer is valid on save.

Fixes #34 