### PR TITLE
Allow opening file with right-click -> open with

### DIFF
--- a/src/dialogs/mainDialog.h
+++ b/src/dialogs/mainDialog.h
@@ -50,7 +50,7 @@ class MainDialog : public QMainWindow {
  public:
     explicit MainDialog(QWidget *parent = 0);
     ~MainDialog();
-    void show();
+    void show(QString playbookPath);
     void fillPlayerInfoDock(PBCPlayerSP player);
     void fillPlayInfoDock(PBCPlaySP play);
     void keyReleaseEvent(QKeyEvent *event);
@@ -68,6 +68,7 @@ class MainDialog : public QMainWindow {
     void saveFormationAs();
     void newPlaybook();
     void savePlaybookAs();
+    void loadPlaybook(QString fileName);
     void openPlaybook();
     void importPlaybook();
     void exportAsPDF();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ int main(int argc, char *argv[]) {
               << BOTAN_VERSION_MINOR << "."
               << BOTAN_VERSION_PATCH << std::endl;
 
+
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication a(argc, argv);
     MainDialog w;
@@ -101,7 +102,11 @@ int main(int argc, char *argv[]) {
 
             }
         }
-        w.show();
+        QString playbookPath;
+        if (argc == 2) {
+            playbookPath = QString(argv[1]);
+        }
+        w.show(playbookPath);
         a.exec();
     } catch(std::exception &e) {
         QString errorString = "Terminating playbook creator. Please open an bug report on "


### PR DESCRIPTION
Fixes #9 

What would be helpful too:
Let the installer register the .pbc extension with the os, especially on Windows.
See e.g. https://stackoverflow.com/questions/15883361/how-do-i-add-a-windows-file-type-association-using-installshield 